### PR TITLE
Add compose.yml for Docker

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,42 @@
+services:
+  spark-master:
+    image: bitnamilegacy/spark:3.5.0-debian-12-r17
+    environment:
+      - SPARK_MODE=master
+      - SPARK_RPC_AUTHENTICATION_ENABLED=no
+      - SPARK_RPC_ENCRYPTION_ENABLED=no
+      - SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED=no
+      - SPARK_SSL_ENABLED=no
+    volumes:
+      - ./notebooks:/home/jovyan/work
+    ports:
+      - "8080:8080"
+      - "7077:7077"
+
+  spark-worker-1:
+    image: bitnamilegacy/spark:3.5.0-debian-12-r17
+    environment:
+      - SPARK_MODE=worker
+      - SPARK_MASTER_URL=spark://spark-master:7077
+      - SPARK_WORKER_MEMORY=1G
+      - SPARK_WORKER_CORES=1
+      - SPARK_RPC_AUTHENTICATION_ENABLED=no
+      - SPARK_RPC_ENCRYPTION_ENABLED=no
+      - SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED=no
+      - SPARK_SSL_ENABLED=no
+    volumes:
+      - ./notebooks:/home/jovyan/work
+    depends_on:
+      - spark-master
+
+  jupyter:
+    image: jupyter/pyspark-notebook:spark-3.5.0
+    ports:
+      - "8888:8888"
+    volumes:
+      - ./notebooks:/home/jovyan/work
+    command: start.sh jupyter notebook --NotebookApp.token=''
+    environment:
+      - JUPYTER_ENABLE_LAB=yes
+    depends_on:
+      - spark-master


### PR DESCRIPTION
Installing spark is no simple task for beginners. Adding a compose.yml for those familiarized with Docker Compose would make the job a lot easier for studying purposes.